### PR TITLE
Use patract parity-wasm at v0.41.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,9 @@
 [profile.release]
 panic = "unwind"
 
+[patch.crates-io]
+parity-wasm = { git = "https://github.com/patractlabs/parity-wasm", branch = "v0.41.0" }
+
 [workspace]
 members = [
     "bin/europa/",


### PR DESCRIPTION
## Desc

Even parity has merged our modification in `parity-wasm`, but for `v0.41.0`, it doesn't contain our feature.