### PR TITLE
change europa rent parameters to zero

### DIFF
--- a/bin/europa/runtime/src/constants.rs
+++ b/bin/europa/runtime/src/constants.rs
@@ -11,15 +11,11 @@ pub mod currency {
 	pub const DOTS: Balance = 1_000_000_000_000; // old dot, one Dot is 100 Dot(new) now
 	pub const DOLLARS: Balance = DOTS / 100; // 10_000_000_000 // one Dollar is 1 Dot(new) now
 	pub const CENTS: Balance = DOLLARS / 100; // 100_000_000 // one Cent is 0.01 Dot(new) now
-	pub const MILLICENTS: Balance = CENTS / 1_000; // 100_000 // one Millicent is 0.00001 Dot(new) now
+	// pub const MILLICENTS: Balance = CENTS / 1_000; // 100_000 // one Millicent is 0.00001 Dot(new) now
 
-	pub const fn deposit(items: u32, bytes: u32) -> Balance {
-		items as Balance * 20 * DOLLARS + (bytes as Balance) * 100 * MILLICENTS
-	}
-
-	pub const fn europa_deposit(items: u32, bytes: u32) -> Balance {
-		items as Balance * 10 * CENTS + (bytes as Balance) * 10 * MILLICENTS
-	}
+	// pub const fn deposit(items: u32, bytes: u32) -> Balance {
+	// 	items as Balance * 20 * DOLLARS + (bytes as Balance) * 100 * MILLICENTS
+	// }
 }
 
 /// Fee-related.

--- a/bin/europa/runtime/src/lib.rs
+++ b/bin/europa/runtime/src/lib.rs
@@ -257,16 +257,13 @@ impl pallet_transaction_payment::Config for Runtime {
 }
 
 parameter_types! {
-	pub TombstoneDeposit: Balance = europa_deposit(
-		1,
-		<pallet_contracts::Pallet<Runtime>>::contract_info_size(),
-	);
-	pub DepositPerContract: Balance = TombstoneDeposit::get();
-	pub const DepositPerStorageByte: Balance = deposit(0, 1);
-	pub const DepositPerStorageItem: Balance = deposit(1, 0);
-	pub RentFraction: Perbill = Perbill::from_rational(1u32, 30 * DAYS);
-	pub const SurchargeReward: Balance = 150 * MILLICENTS;
-	pub const SignedClaimHandicap: u32 = 2;
+    pub const TombstoneDeposit: Balance = 0;
+    pub const DepositPerContract: Balance = 0;
+    pub const DepositPerStorageByte: Balance = TombstoneDeposit::get();
+    pub const DepositPerStorageItem: Balance = 0;
+    pub RentFraction: Perbill = Perbill::zero();
+    pub const SurchargeReward: Balance = 0;
+    pub const SignedClaimHandicap: u32 = 0;
 	pub const MaxValueSize: u32 = 16 * 1024;
 	// The lazy deletion runs inside on_initialize.
 	pub DeletionWeightLimit: Weight = AVERAGE_ON_INITIALIZE_RATIO *


### PR DESCRIPTION
substrate have removed the rent in pallet-contracts in newest substrate after this pr https://github.com/paritytech/substrate/pull/9669. 

but we do not wanna update current substrate to new version, for we are waiting substrate to release 4.0.0.

thus, we just change the rent parameters to zero, it will cause the same result compared with removed rent pallet-contracts.